### PR TITLE
Fix english and italian translations of lipu

### DIFF
--- a/js/tokipona.json
+++ b/js/tokipona.json
@@ -264,8 +264,8 @@
         "rus": "длинный, очень тонкий предмет, верёвка, нитка, волос, цепь",
         "image": "linja"
     }, {
-        "eng": "a flat, flexible object, paper, card, ticket",
-        "ita": "un appartamento, oggetto flessibile, carta, cartoncino, biglietti",
+        "eng": "a flat and flexible object, paper, card, ticket",
+        "ita": "un oggetto piatto e flessibile, carta, cartoncino, biglietti",
         "toki": "lipu",
         "rus": "плоский и гибкий предмет, бумага, карточка, билет",
         "image": "lipu"


### PR DESCRIPTION
The comma in "a flat, flexible object" makes it sound like *lipu* could mean either a flat/apartment or a flexible object.

Since it seems like the italian translation was based off the english translation, the translator incorrectly translated "a flat and flexible object" into "un appartemento (an apartment where people live) \<comma\> ogetto flessibile (object flexible)"